### PR TITLE
Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 <br/>
 ## ABOUT
 
+[![Image from Gyazo](https://i.gyazo.com/616b0d03b97d5cd66d8e9cb4ebbc8570.gif)](https://gyazo.com/616b0d03b97d5cd66d8e9cb4ebbc8570)
+
 Bytebite is an attempt to build Ubereats as faithfully as possible using a Flask backend and React frontend, for educational purposes.
 
 ### TEAM
@@ -44,20 +46,33 @@ Inkscape - Custom SVG Design
 
 ### FEATURES
 
+[![Image from Gyazo](https://i.gyazo.com/735ac14b8a052dd86ced2b75cb54fb0b.jpg)](https://gyazo.com/735ac14b8a052dd86ced2b75cb54fb0b)
+
+
 Bytebite is a clone of UberEats developed for educational purposes by Brian John, Gerrod White, and Daniel Legendre for App Academy. The purpose for the project was to work as a team to create a web application with a Flask backend to culminate the Python portion of the curriculum. Bytebite is meant to provide the software side of a food delivery service which delivers an order from a user to a restaurant, from a restaurant to a driver and from the driver to the user.
 
 ### Orders
+
+[![Image from Gyazo](https://i.gyazo.com/3c8def50cff64a735780ad7c55dd89d4.png)](https://gyazo.com/3c8def50cff64a735780ad7c55dd89d4)
+
+[![Image from Gyazo](https://i.gyazo.com/23372e3a4ab5bd91aefb64ae66703308.png)](https://gyazo.com/23372e3a4ab5bd91aefb64ae66703308)
 
 Orders can be created by adding any item from any restaurant to the user's cart. The items in the order and their cost can be accessed at any time from the user's shopping cart located in the navigation bar. The order can be deleted at any time from the cart interface, and also taken to checkout where they will be prompted for payment information and desired delivery options. Old orders are archived in the Order History tab of the menu, and usual or favorite orders can be reordered with the click of a button.
 
 ### Restaurants
 
+[![Image from Gyazo](https://i.gyazo.com/3bb06f85c180da280ccad4d9ca9db117.png)](https://gyazo.com/3bb06f85c180da280ccad4d9ca9db117)
+
 Restaurants can be created from the restaurant form page in the options menu. Once a restaurant is created, it is published to the Bytebite main feed where other users can order from it. The restaurants can be managed, edited, and deleted at any time from the manage restaurants page. Restaurants can be searched by name in the search bar so a user can quickly find their favorite restaurant.
 
 ### Menu Items
 
+[![Image from Gyazo](https://i.gyazo.com/9dda37a871389c259127fb72dfad1630.jpg)](https://gyazo.com/9dda37a871389c259127fb72dfad1630)
+
 Restaurants all serve menu items. These are represented to the user via image and text descriptions. They can be updated seamlessly through the restaurant management page.
 
 ### Reviews
+
+[![Image from Gyazo](https://i.gyazo.com/426a082a269cf188399e70edbdfba9b4.png)](https://gyazo.com/426a082a269cf188399e70edbdfba9b4)
 
 Users can leave reviews on restaurants letting other users and the restaurants know their experiences. These reviews are displayed prominently at the top of a restaurant's page and the ratings are aggregated so that users can tell at a glance how well-liked a restaurant is. Reviews can be updated or deleted at any time through the users reviews page.

--- a/app/api/restaurant_routes.py
+++ b/app/api/restaurant_routes.py
@@ -28,17 +28,17 @@ def search():
 
 @restaurant_routes.route('/delivery')
 def home():
-    all_restaurants = db.session.query(Restaurant).filter(Restaurant.delivery).all()
+    req_page = request.args.get('page')
+    all_restaurants = Restaurant.query.paginate(page=int(req_page), per_page=12, count=True)
     lst = list()
-    dic = {"restaurants": lst}
-    for restaurant in all_restaurants:
+    for restaurant in all_restaurants.items:
         if restaurant.delivery:
             rest_entry = restaurant.to_dict_main_page()
             rest_entry['Reviews'] = [review.to_dict() for review in restaurant.reviews]
             rest_entry['numReviews'] = len(rest_entry['Reviews'])
             lst.append(rest_entry)
 
-    return dic
+    return {"restaurants": lst, "total": all_restaurants.total}
 
 @restaurant_routes.route('/current')
 @login_required

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -23,4 +23,5 @@ class Review(db.Model):
             'user_id': self.user_id,
             'restaurant_id': self.restaurant_id,
             'user': self.user.to_dict(),
+            'restaurant': self.restaurant.name,
         }

--- a/frontend/src/SearchPage/SearchPage.jsx
+++ b/frontend/src/SearchPage/SearchPage.jsx
@@ -1,4 +1,3 @@
-import { useLocation, useSearchParams } from "react-router-dom"
 import RestaurantTile from "../components/MainPage/RestaurantTile";
 import { useEffect } from "react";
 import { restaurantsArray, thunkSearchRestaurants } from "../redux/restaurants";
@@ -6,10 +5,10 @@ import { useDispatch, useSelector } from "react-redux";
 
 const SearchPage = () => {
     const dispatch = useDispatch();
-    const url = new URL(window.location.href)
     useEffect(() => {
+        const url = new URL(window.location.href)
         dispatch(thunkSearchRestaurants(url.search))
-    }, [])
+    }, [dispatch])
 
     const searched = useSelector(restaurantsArray)
 
@@ -20,7 +19,7 @@ const SearchPage = () => {
             <div className="main_page_primary">
                 {searched.length > 0 && searched.map((rest) => {
                     return (
-                        <RestaurantTile restaurantInfo={rest} />
+                        <RestaurantTile key={rest.id} restaurantInfo={rest} />
                     )
                 })}
                 {searched.length < 1 && <div>

--- a/frontend/src/SearchPage/SearchPage.jsx
+++ b/frontend/src/SearchPage/SearchPage.jsx
@@ -14,19 +14,18 @@ const SearchPage = () => {
     const searched = useSelector(restaurantsArray)
 
     return (
-        <div className="textmark">
+        <div className="textmark searchMain">
             <h1>Search results</h1>
-            <div>
-                <div>
-                    {searched.length > 0 && searched.map((rest) => {
-                        return (
-                            <RestaurantTile restaurantInfo={rest} />
-                        )
-                    })}
-                    {searched.length < 1 && <div>
-                        <h3>No restaurants were found that matched your search.</h3>
-                    </div>}
-                </div>
+
+            <div className="main_page_primary">
+                {searched.length > 0 && searched.map((rest) => {
+                    return (
+                        <RestaurantTile restaurantInfo={rest} />
+                    )
+                })}
+                {searched.length < 1 && <div>
+                    <h3>No restaurants were found that matched your search.</h3>
+                </div>}
             </div>
         </div>
     )

--- a/frontend/src/components/CheckoutPage/DeliveryDetailsForm.jsx
+++ b/frontend/src/components/CheckoutPage/DeliveryDetailsForm.jsx
@@ -22,7 +22,7 @@ const DeliveryDetailsForm = ({ order, items }) => {
                     <h2 className="textmark">{`Delivery estimate`}</h2>
                     <DeliveryOption name="priority" icon={<FaBolt style={{ fontSize: '20px', color: 'green' }} />} bold={'Priority'} sub={`${order?.minTime || "10"}-${order?.maxTime || '25 min • Delivery directly to you'}`} surcharge={order?.prioritySurcharge || 2} clicker={() => alert('Feature coming soon!')} />
                     <DeliveryOption name="standard" icon={<FaShoppingBag className="icon" />} bold={'Standard'} sub={`${order?.minTime || "15"}-${order?.maxTime || '30 min'}`} black={true}/>
-                    <DeliveryOption name="schedule" icon={<FaCalendarDay className="icon" />} bold={'Schedule'} sub={'Select a time'} clickWholeDiv={() => alert('Feature coming soon!')} clicker={() => alert('Feature coming soon!')}/>
+                    <DeliveryOption name="schedule" icon={<FaCalendarDay className="icon" />} bold={'Schedule'} sub={'Select a time'} clicker={() => alert('Feature coming soon!')}/>
                 </div>
             </div>
             <div className="breaker"></div>

--- a/frontend/src/components/CheckoutPage/DetailsWithEditDiv.jsx
+++ b/frontend/src/components/CheckoutPage/DetailsWithEditDiv.jsx
@@ -1,4 +1,4 @@
-const DetailsEdit = ({ icon, bold, sub, button, surcharge, clicker, clickWholeDiv }) => {
+const DetailsEdit = ({ icon, bold, sub, button, surcharge, clicker }) => {
 
 
 

--- a/frontend/src/components/CurrentRestaurantsPage/CurrentRestaurantsPage.jsx
+++ b/frontend/src/components/CurrentRestaurantsPage/CurrentRestaurantsPage.jsx
@@ -48,7 +48,7 @@ const CurrentRestaurantsPage = () => {
           <div className="current_restaurants_container">
             {restaurants.map((restaurant) => {
               return (
-                <div className="my-restaurant-tile">
+                <div className="my-restaurant-tile" key={restaurant.id}>
                   <RestaurantTile restaurantInfo={restaurant} key={restaurant.id} />
                   <div className="my-restaurant-buttons">
                     <button className="restaurant-modal-button">

--- a/frontend/src/components/CurrentReviewsPage/CurrentReviewsBox.jsx
+++ b/frontend/src/components/CurrentReviewsPage/CurrentReviewsBox.jsx
@@ -1,5 +1,3 @@
-import { useSelector } from "react-redux"
-import { restaurantById } from "../../redux/restaurants";
 import { FaStar } from "react-icons/fa"
 import { useNavigate } from "react-router-dom";
 import icons from '../StorePage/utils/iconsForReviewBox'
@@ -12,9 +10,7 @@ const CurrentReviewBox = ({ review }) => {
   const randomIconIndex = Math.floor(Math.random() * icons.length);
   const randomIcon = icons[randomIconIndex]
   const color = colors[Math.floor(Math.random() * colors.length)]
-
-  const id = review.restaurant_id
-  const reviewedRestaurant = useSelector((state) => restaurantById(state, id))
+  const reviewedRestaurant = review.restaurant
 
   if (!reviewedRestaurant) {
     return (
@@ -26,8 +22,8 @@ const CurrentReviewBox = ({ review }) => {
     <div className="current-reviewBox">
       <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }}>
         <div style={{ display: 'flex', background: color, borderRadius: '50%', justifyContent: 'center', alignItems: 'center', padding: '6px', marginRight: '5px' }}>
-          {randomIcon} 
-          
+          {randomIcon}
+
         </div>
         <button className="currentReviewBoxName" onClick={() => navigate(`/store/${reviewedRestaurant.name}`)}>{reviewedRestaurant.name}</button>
       </div>

--- a/frontend/src/components/CurrentReviewsPage/CurrentReviewsPage.jsx
+++ b/frontend/src/components/CurrentReviewsPage/CurrentReviewsPage.jsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from "react-redux"
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { reviewsArray, thunkUsersReviews } from "../../redux/reviews";
 import DeleteReviewModal from "./DeleteReviewModal";
 import OpenModalButton from '../OpenModalButton'
@@ -7,14 +7,12 @@ import CurrentReviewBox from "./CurrentReviewsBox";
 import UpdateReviewModal from "./UpdateReviewModal";
 import Spinner from "../Spinner";
 import './CurrentReviewsPage.css'
-import { thunkAllRestaurants } from "../../redux/restaurants";
 
 const CurrentReviewsPage = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(thunkUsersReviews())
-    dispatch(thunkAllRestaurants())
   }, [dispatch])
 
   const reviews = useSelector(reviewsArray)
@@ -35,8 +33,8 @@ const CurrentReviewsPage = () => {
                 <CurrentReviewBox review={review} key={review.id} />
                 <div className="review-buttons">
                   < OpenModalButton className="review-modal-button"
-                  modalComponent={<DeleteReviewModal id={review.id}/>}
-                  buttonText="Delete" />
+                    modalComponent={<DeleteReviewModal id={review.id} />}
+                    buttonText="Delete" />
                   < OpenModalButton className="review-modal-button"
                     modalComponent={<UpdateReviewModal restaurant_id={review.restaurant_id} />}
                     buttonText="Update"

--- a/frontend/src/components/MainPage/BottomDiv.jsx
+++ b/frontend/src/components/MainPage/BottomDiv.jsx
@@ -1,0 +1,39 @@
+import LogoDiv from "../Navigation/LogoDiv"
+import { Link } from "react-router-dom"
+const MainPageBottomDiv = () => {
+    const clicker = () => {
+        alert("Feature coming soon!")
+    }
+    return (
+        <div className="bottomDivMain textmark">
+            <div className="left">
+                <LogoDiv />
+                <div className="dloadButtons">
+                    <img onClick={() => clicker()} className="dloadImg" src="https://bmj1988-api-pics.s3.amazonaws.com/foodpics/dloadApple.webp" />
+                    <img onClick={() => clicker()} className="dloadImg" src="https://bmj1988-api-pics.s3.amazonaws.com/foodpics/dloadGoogle.webp" />
+
+                </div>
+            </div>
+            <div className="right">
+                <div className="linkList">
+                    <Link onClick={() => clicker()} className="bottomMainLinks">Get Help</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">Buy gift cards</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">Add your restaurant</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">Sign up to deliver</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">Create a business account</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">Promotions</Link>
+                </div>
+                <div className="linkList">
+                    <Link onClick={() => clicker()} className="bottomMainLinks">Restaurants near me</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">View all cities</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">View all countries</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">Pickup near me</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">About Byte Bite</Link>
+                    <Link onClick={() => clicker()} className="bottomMainLinks">English</Link>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default MainPageBottomDiv;

--- a/frontend/src/components/MainPage/BottomLine.jsx
+++ b/frontend/src/components/MainPage/BottomLine.jsx
@@ -1,0 +1,26 @@
+import { FaFacebookSquare, FaInstagramSquare, FaTwitterSquare } from "react-icons/fa"
+import { Link } from "react-router-dom"
+
+const BottomLine = () => {
+    const clicker = () => {
+        alert("Feature coming soon!")
+    }
+
+    return (
+        <div className="bottomDivMain">
+            <div className="bottomLineSocialIcons">
+                <FaFacebookSquare onClick={() => clicker()} />
+                <FaTwitterSquare onClick={() => clicker()} />
+                <FaInstagramSquare onClick={() => clicker()} />
+            </div>
+            <div className="bottomLineLinks">
+                <Link className="bottomMainLinks" onClick={() => clicker()}>Privacy Policy</Link>
+                <Link className="bottomMainLinks" onClick={() => clicker()}>Terms</Link>
+                <Link className="bottomMainLinks" onClick={() => clicker()}>Pricing</Link>
+                <Link className="bottomMainLinks" onClick={() => clicker()}>Do not sell or share my personal information</Link>
+            </div>
+        </div>
+    )
+}
+
+export default BottomLine;

--- a/frontend/src/components/MainPage/Main.css
+++ b/frontend/src/components/MainPage/Main.css
@@ -1,13 +1,12 @@
 .main_page_primary {
     /* display: flex; */
-    display: grid;
-    grid-template-columns: repeat(4, 288px);
+    display: flex;
+    flex-wrap: wrap;
     max-width: 1280px;
-    padding: 0 40px;
-    min-width: 1024px;
+    min-width: 400px;
     margin: 0 auto;
     box-sizing: border-box;
-    gap: 12px;
+    gap: 24px;
     justify-content: space-evenly;
 }
 
@@ -82,7 +81,7 @@
     color: black;
     width: 288px;
     height: 190px;
-    cursor:pointer;
+    cursor: pointer;
 }
 
 .restaurant-div {
@@ -127,7 +126,7 @@
 }
 
 .ratingText {
-    display:flex;
+    display: flex;
     justify-content: center;
     align-items: center;
     padding-top: 5px;
@@ -138,4 +137,128 @@
     flex-direction: column;
     align-items: center;
     margin-top: 100px;
+}
+
+.arrowButtonWrapperDiv {
+    display: flex;
+    width: inherit;
+    justify-content: center;
+    margin-bottom: 40px;
+}
+
+.arrowButtons {
+    width: 36px;
+    padding: 2px 4px;
+    min-height: 0px;
+    font-size: 14px;
+    height: 36px;
+    display: flex;
+    justify-content: center;
+    line-height: 24px;
+    border-radius: 500px;
+    font-weight: 500;
+    cursor: pointer;
+    background: #EEEEEE;
+    align-items: center;
+    color: black;
+    box-sizing: border-box;
+    position: absolute;
+}
+
+.arrowButtonsUnavailable {
+    width: 36px;
+    padding: 2px 4px;
+    min-height: 0px;
+    font-size: 14px;
+    height: 36px;
+    display: flex;
+    justify-content: center;
+    line-height: 24px;
+    border-radius: 500px;
+    font-weight: 500;
+    align-items: center;
+    color: gray;
+    box-sizing: border-box;
+    position: absolute;
+    background: #F3F3F3;
+}
+
+.arrowButtons:hover {
+    background-color: #d4d4d4;
+}
+
+.mainBottomBreaker {
+    display: flex;
+    width: 100%;
+    height: 1px;
+    background: #F3F3F3;
+    margin-top: 60px;
+}
+
+.bottomDivMain {
+    border-bottom: 1px solid #F3f3f3;
+    display: flex;
+    width: 68%;
+    height: fit-content;
+    justify-content: space-between;
+    margin: auto;
+    padding: 40px;
+}
+
+.bottomDivMain .left {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.bottomDivMain .right {
+    display: flex;
+    gap: 100px;
+}
+
+.right .linkList {
+    display: flex;
+    flex-direction: column;
+    font-size: 18px;
+    gap: 20px;
+}
+
+.dloadImg {
+    width: 150px;
+    height: 40px;
+    margin-right: 20px;
+}
+
+.bottomMainLinks {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+}
+
+.bottomMainLinks:hover {
+    text-decoration: underline;
+}
+
+.bottomLineMain {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 14px;
+    margin: auto;
+    width: 68%;
+}
+
+.bottomLineLinks {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    gap: 35px;
+}
+
+.bottomLineSocialIcons {
+    width: 25%;
+    display: flex;
+    gap: 25px;
+    font-size: 20px;
 }

--- a/frontend/src/components/MainPage/MainPage.jsx
+++ b/frontend/src/components/MainPage/MainPage.jsx
@@ -4,32 +4,50 @@ import { useDispatch, useSelector } from 'react-redux'
 import Spinner from "../Spinner"
 import RestaurantTile from "./RestaurantTile"
 import CategoryScroller from "./CategoryScroller"
+import { FaArrowUp, FaArrowDown } from "react-icons/fa"
+import MainPageBottomDiv from "./BottomDiv"
+import BottomLine from "./BottomLine"
 
 const MainPage = () => {
     const [loaded, setLoaded] = useState(false)
+    const [page, setPage] = useState(1)
     const dispatch = useDispatch();
     const restaurants = useSelector(restaurantsArray)
+    const [total, setTotal] = useState(0)
 
     useEffect(() => {
-        dispatch(thunkAllRestaurants()).then(() => setLoaded(true))
-    }, [dispatch])
+        dispatch(thunkAllRestaurants(page)).then((total) => setTotal(total)).then(() => setLoaded(true))
+    }, [dispatch, page])
 
     if (!loaded) {
         return (
-            <Spinner/>
+            <Spinner />
         )
     }
-
+    console.log(total)
     return (
         <>
-        <CategoryScroller />
-        <div className="main_page_primary">
-        {restaurants.map((restaurant) => {
-            return (
-                <RestaurantTile restaurantInfo={restaurant} key={restaurant.id}/>
-            )
-        })}
-        </div>
+            <CategoryScroller />
+            <div className="arrowButtonWrapperDiv">
+                <div className={page > 1 ? "arrowButtons" : "arrowButtonsUnavailable"} onClick={page > 1 ? () => setPage(page - 1) : null}>
+                    <FaArrowUp />
+                </div>
+            </div>
+            <div className="main_page_primary">
+                {restaurants.map((restaurant) => {
+                    return (
+                        <RestaurantTile restaurantInfo={restaurant} key={restaurant.id} />
+                    )
+                })}
+            </div>
+            <div className="arrowButtonWrapperDiv">
+                <div className={page * 12 < total ? "arrowButtons" : "arrowButtonsUnavailable"} onClick={page * 12 < total ? () => setPage(page + 1) : null}>
+                    <FaArrowDown />
+                </div>
+            </div>
+            <div className="mainBottomBreaker"></div>
+            <MainPageBottomDiv />
+            <BottomLine />
         </>
     )
 }

--- a/frontend/src/components/MenuItemModal/MenuItemModal.jsx
+++ b/frontend/src/components/MenuItemModal/MenuItemModal.jsx
@@ -12,7 +12,7 @@ const MenuItemModal = ({ item }) => {
         setMenuItemId(item.id)
         setPrice(item.price)
         setRestaurantId(item.restaurantId)
-    }, [item])
+    }, [item, setMenuItemId, setPrice, setRestaurantId])
 
 
 

--- a/frontend/src/components/MenuItemModal/QuantityDropDown.jsx
+++ b/frontend/src/components/MenuItemModal/QuantityDropDown.jsx
@@ -25,7 +25,7 @@ const QuantityDropdown = ({ menu_item_id }) => {
             setQuantity(1)
             setItemQuantity(1)
         }
-    }, [oldQuantity])
+    }, [oldQuantity, setItemQuantity, setQuantity])
 
     useEffect(() => {
         if (!showQuantityList) return;

--- a/frontend/src/components/Navigation/Cart.jsx
+++ b/frontend/src/components/Navigation/Cart.jsx
@@ -12,7 +12,7 @@ const ShoppingCart = () => {
 
     useEffect(() => {
         dispatch(thunkGetCurrentOrder())
-    }, [])
+    }, [dispatch])
 
     useEffect(() => {
         const reduce = cart.reduce((acc, val) => acc + val.quantity, 0,)

--- a/frontend/src/components/Navigation/Navigation.css
+++ b/frontend/src/components/Navigation/Navigation.css
@@ -134,6 +134,10 @@
   min-width: 400px;
 }
 
+.searchBar input:focus {
+  border: none;
+}
+
 .shoppingCart {
   display: flex;
   cursor: pointer;
@@ -196,4 +200,8 @@
   min-width: 200px;
   max-width: 500px;
   width: 300px;
+}
+
+.searchBar input:focus {
+  outline: none;
 }

--- a/frontend/src/components/Navigation/OptionModals/DeliveryDetailsModal.jsx
+++ b/frontend/src/components/Navigation/OptionModals/DeliveryDetailsModal.jsx
@@ -7,7 +7,7 @@ import { useModal } from '../../../context/Modal'
 import DeliveryInput from './DeliveryInput'
 
 const DeliveryDetailModal = () => {
-    const { stAddress, setStAddress, deliveryTime, setDeliveryTime, locality, setLocality, city, setCity } = useCartContext()
+    const { stAddress, setStAddress, deliveryTime, locality, city} = useCartContext()
     const { setModalContent, closeModal } = useModal();
 
     const addressClicker = () => {

--- a/frontend/src/components/Navigation/SearchBar.jsx
+++ b/frontend/src/components/Navigation/SearchBar.jsx
@@ -14,7 +14,7 @@ const SearchBar = () => {
 
     return (<div className='searchBar'>
         <FaSearch style={{ margin: '10px' }} onClick={(e) => searchRestaurants(e)} />
-        <input type='search' placeholder='Food, groceries, drinks, etc' onChange={(e) => setSearch(e.target.value)} onsubmit={(e) => searchRestaurants(e)} />
+        <input type='search' placeholder='Food, groceries, drinks, etc' onChange={(e) => setSearch(e.target.value)} onSubmit={(e) => searchRestaurants(e)} />
     </div>)
 }
 

--- a/frontend/src/components/OrderHistory/OrderHistoryPage.jsx
+++ b/frontend/src/components/OrderHistory/OrderHistoryPage.jsx
@@ -1,11 +1,11 @@
-import { useLoaderData, useLocation, useNavigate } from "react-router-dom";
+import { useLoaderData, useNavigate } from "react-router-dom";
 import DetailsEdit from "../CheckoutPage/DetailsWithEditDiv";
 import { FaChevronRight } from "react-icons/fa";
 
 const OrderHistoryPage = () => {
     const navigate = useNavigate();
     const orders = useLoaderData();
-    const firstTen = orders.orders.slice(0, 10)
+    const firstTen = orders ? orders.orders.slice(0, 20) : []
 
     // const deleteOrder = async (orderId) => {
     //     const response = await fetch(`/api/orders/${orderId}`, {

--- a/frontend/src/components/SignupFormPage/SignupFormPage.jsx
+++ b/frontend/src/components/SignupFormPage/SignupFormPage.jsx
@@ -49,7 +49,7 @@ function SignupFormPage() {
         <label className="login-label">
           Email
           </label>
-          <input input className="signup-page-input"
+          <input className="signup-page-input"
             type="text"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -59,7 +59,7 @@ function SignupFormPage() {
         <label className="login-label">
           Username
           </label>
-          <input input className="signup-page-input"
+          <input className="signup-page-input"
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
@@ -69,7 +69,7 @@ function SignupFormPage() {
         <label className="login-label">
           Password
           </label>
-          <input input className="signup-page-input"
+          <input className="signup-page-input"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -79,7 +79,7 @@ function SignupFormPage() {
         <label className="login-label">
           Confirm Password
           </label>
-          <input input className="signup-page-input"
+          <input className="signup-page-input"
             type="password"
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}

--- a/frontend/src/components/StorePage/ShoppingCart/cart.css
+++ b/frontend/src/components/StorePage/ShoppingCart/cart.css
@@ -9,7 +9,7 @@
     line-height: 24px;
     border-radius: 500px;
     font-weight: 500;
-    cursor: 'pointer';
+    cursor: pointer;
     background: #FFFFFF;
     align-items: center;
     color: black;

--- a/frontend/src/redux/restaurants.js
+++ b/frontend/src/redux/restaurants.js
@@ -73,15 +73,17 @@ export const thunkRestaurantById = (id) => async (dispatch) => {
     }
 };
 
-export const thunkAllRestaurants = () => async (dispatch) => {
-    const response = await fetch("/api/restaurants/delivery");
+export const thunkAllRestaurants = (page = 1) => async (dispatch) => {
+    const params = new URLSearchParams(`page=${page}`)
+    const response = await fetch(`/api/restaurants/delivery?${params}`);
     if (response.ok) {
-        const allRestaurants = await response.json();
+        const allRestaurants = await response.json()
         dispatch(loadRestaurants(allRestaurants));
-        return allRestaurants;
+        return allRestaurants.total;
     }
     else {
-        const error = response;
+        console.log(response)
+        const error = await response.json();
         return error;
     }
 };


### PR DESCRIPTION
This represents what will likely be the greenlit version of the app depending on the feature review process. Category search, restaurant name search, pagination of the main page, adequate seeders created through faker, as well as an updated look for the main page with a bunch of links (mostly alerts) to mimic the actual appearance of the UberEats main page.  This comes after the addition of Re-Order. Likely next steps include: revamping the backend to include main attributes that are needed to make the page function as intended (a real food delivery app) including addresses on orders, a splash page which can more effectively mimic the ubereats mainpage using multiple, highly paginated rows of restaurant selections based on restaurant categories (expanded mostly to include pricing data and location data, but some others), and finally my own Order History page, which should have an order summary more akin to what shows up on the order checkout page which appears upon selection of a previous order, as well as some more options. As with almost any project with a small engineering team and limited time and resources, there is much that could be added, but I believe what we've created though flawed, succeeds in the task we were assigned.